### PR TITLE
Add netboot capability (including preliminary iPXE support)

### DIFF
--- a/.github/workflows/xnodeos-build-netboot.yml
+++ b/.github/workflows/xnodeos-build-netboot.yml
@@ -1,0 +1,36 @@
+---
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  build:
+    name: Build XnodeOS ISO Image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Build XnodeOS Netboot Image
+        run: make netboot
+      - name: Archive iPXE Chainload Script as Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ipxe
+          path: result/ipxe
+      - name: Archive XnodeOS Linux Kernel Image as Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel
+          path: result/kernel
+      - name: Archive XnodeOS Initial Ramdisk Image as Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: initrd
+          path: result/initrd

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-.PHONY: clean iso all
+.PHONY: clean iso ipxe install all default
+
+default:
+	echo 'you must choose one of: clean, iso, or netboot'
 
 clean:
 	rm -rf result
 
 iso:
-	nix --extra-experimental-features nix-command --extra-experimental-features flakes build '.#iso'
+	nix build --extra-experimental-features nix-command --extra-experimental-features flakes -L --print-out-paths '.#iso'
 
-install:
-	sudo cp result/iso/nixos.iso ~/Downloads/nixos.iso
-
-all: clean iso
+netboot:
+	nix build --extra-experimental-features nix-command --extra-experimental-features flakes -L --print-out-paths '.#netboot'

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # XnodeOS
-XnodeOS is a modularised configurable operating-system for servers built on NixOS, you can find all of our nix flakes and modules here.
+XnodeOS is a modularised opinionated-yet-configurable operating system for Xnodes based on NixOS.
 
 ## building
 1. `make clean`
-2. `make iso`
+2. `make iso` or `make netboot`
 
 ## requirements
 You must have the nix package installed for this build to work.
 
+## testing netboot
+```
+$ make clean netboot
+$ cd result
+$ python3 -m http.server&
+$ qemu-system-x86_64 -enable-kvm -m 2G -cpu 2 -serial mon:stdio -net user,bootfile="http://localhost:8000/ipxe" -net nic -msg timestamp=on
+```
 
 ### FEATURE: SSH-Keys
 In the local environment where you are running make iso you need to pass the key in by one of the following methods:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You must have the nix package installed for this build to work.
 $ make clean netboot
 $ cd result
 $ python3 -m http.server&
-$ qemu-system-x86_64 -enable-kvm -m 2G -cpu 2 -serial mon:stdio -net user,bootfile="http://localhost:8000/ipxe" -net nic -msg timestamp=on
+$ qemu-system-x86_64 -enable-kvm -m 2G -cpu 2 -serial mon:stdio -net user,bootfile="http://127.0.0.1:8000/ipxe" -net nic -msg timestamp=on
 ```
 
 ### FEATURE: SSH-Keys

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
       packages = {
         x86_64-linux = {
           iso = import ./packages/iso.nix flakeContext;
+          netboot = import ./packages/netboot.nix flakeContext;
         };
       };
     };

--- a/packages/image/format/netboot.nix
+++ b/packages/image/format/netboot.nix
@@ -21,8 +21,8 @@
       text = ''
         #!ipxe
         # TODO: MAKE CONFIGURABLE WITH iPXE VARS for CHAINLOAD
-        kernel http://localhost:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}
-        initrd http://localhost:8000/initrd
+        kernel http://127.0.0.1:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+        initrd http://127.0.0.1:8000/initrd
         boot
       '';
     };

--- a/packages/image/format/netboot.nix
+++ b/packages/image/format/netboot.nix
@@ -1,0 +1,33 @@
+{modulesPath, pkgs, config, ... }: {
+
+  imports = [
+    "${toString modulesPath}/installer/netboot/netboot-minimal.nix"
+  ];
+
+  system.build = rec {
+    image = pkgs.runCommand "image" { buildInputs = [ pkgs.nukeReferences ]; } ''
+      mkdir $out
+      cp ${config.system.build.kernel}/${config.system.boot.loader.kernelFile} $out/kernel
+      cp ${config.system.build.netbootRamdisk}/initrd $out/initrd
+      cp ${config.system.build.ipxe_script} $out/ipxe
+      echo "init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}" > $out/cmdline
+
+      nuke-refs $out/kernel
+    '';
+
+    ipxe_script = pkgs.writeTextFile {
+      executable = false;
+      name = "ipxe";
+      text = ''
+        #!ipxe
+        # TODO: MAKE CONFIGURABLE WITH iPXE VARS for CHAINLOAD
+        kernel http://localhost:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+        initrd http://localhost:8000/initrd
+        boot
+      '';
+    };
+
+  };
+
+  formatAttr = "image";
+}

--- a/packages/netboot.nix
+++ b/packages/netboot.nix
@@ -1,0 +1,44 @@
+{ inputs, ... }@flakeContext:
+let
+  netboot = { config, lib, pkgs, ... }: {
+    config = {
+      documentation = {
+        nixos = {
+          enable = false;
+        };
+        doc = {
+          enable = false;
+        };
+      };
+      services = {
+        getty = {
+          greetingLine = ''<<< Welcome to Openmesh Xnode/OS ${config.system.nixos.label} (\m) - \l >>>'';
+        };
+      };
+      environment = {
+        systemPackages = [
+          pkgs.nyancat
+        ];
+      };
+      networking = {
+        hostName = "xnode";
+      };
+      users = {
+        users = {
+          xnode = {
+            isNormalUser = true;
+            password = "xnode";
+          };
+        };
+      };
+    };
+  };
+in
+inputs.nixos-generators.nixosGenerate {
+  system = "x86_64-linux";
+  customFormats = { "netboot" = import ./image/format/netboot.nix; };
+  format = "netboot";
+  modules = [
+    netboot
+  ];
+}


### PR DESCRIPTION
This set of commits permits the building of iPXE compatible netboot images. Note that the generated iPXE script is not configurable and must be updated for each use case such that it pulls the kernel and initrd from the correct endpoint. The current generated file, per documentation, is sufficient for testing and immediate integration purposes.

This does duplicate configuration between iso and netboot targets, however, this will be quickly factored out - just keeping things minimal for this PR.