### PR TITLE
Feature/initial kexec support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ iso:
 
 netboot:
 	nix build --extra-experimental-features nix-command --extra-experimental-features flakes -L --print-out-paths --show-trace '.#netboot'
+
+kexec:
+	nix build --extra-experimental-features nix-command --extra-experimental-features flakes -L --print-out-paths --show-trace '.#kexec'

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         x86_64-linux = {
           iso = import ./systems/iso.nix flakeContext;
           netboot = import ./systems/netboot.nix flakeContext;
+          kexec = import ./systems/kexec.nix flakeContext;
         };
       };
     };

--- a/systems/kexec.nix
+++ b/systems/kexec.nix
@@ -1,0 +1,57 @@
+{ inputs, ... }@flakeContext:
+let
+  kexec = { config, lib, pkgs, ... }: {
+    imports = [
+      ../repo/modules/services/openmesh/xnode/admin.nix
+    ];
+    config = {
+      documentation = {
+        nixos = {
+          enable = false;
+        };
+        doc = {
+          enable = false;
+        };
+      };
+      services = {
+        openmesh = {
+          xnode = {
+            admin = {
+              enable = true;
+            };
+          };
+        };
+        getty = {
+          greetingLine = ''<<< Welcome to Openmesh XnodeOS ${config.system.nixos.label} (\m) - \l >>>'';
+        };
+      };
+      environment = {
+        systemPackages = with pkgs; [
+          nyancat
+        ];
+      };
+      kexec = {
+        squashfsCompression = "gzip -Xcompression-level 1";
+      };
+      networking = {
+        hostName = "xnode";
+      };
+      users = {
+        users = {
+          xnode = {
+            isNormalUser = true;
+            password = "xnode";
+            extraGroups = [ "wheel" ];
+          };
+        };
+      };
+    };
+  };
+in
+inputs.nixos-generators.nixosGenerate {
+  system = "x86_64-linux";
+  format = "kexec";
+  modules = [
+    kexec
+  ];
+}


### PR DESCRIPTION
Builds a kexec variant for booting on platforms which do not support iPXE but which do have support for only a limited number of parent Linux distributions.

Further speeds up build times using differing, less effective but faster, squashfs compression operation parameters.

This PR also provides fixes for startup of xnode-agent. (in the future, we really shouldn't combine these PRs but I messed up and I think it's ok for now as long as you're ok with this given it really didn't work before.)