### PR TITLE
Add small kexec shim for systems that support cloud-init in the case that the cloud provider doesn't support any other method of booting our OS.

### DIFF
--- a/systems/custom-formats/kexec.nix
+++ b/systems/custom-formats/kexec.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  pkgs,
+  lib,
+  modulesPath,
+  options,
+  ...
+}: let
+in {
+  imports = [
+    "${toString modulesPath}/installer/netboot/netboot-minimal.nix"
+  ];
+
+  system.build = rec {
+    image = pkgs.runCommand "image" { buildInputs = [ pkgs.nukeReferences ]; } ''
+      mkdir $out
+      cp ${config.system.build.kernel}/${config.system.boot.loader.kernelFile} $out/kernel
+      cp ${config.system.build.netbootRamdisk}/initrd $out/initrd
+      echo "init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}" > $out/cmdline
+      nuke-refs $out/kernel
+    '';
+    
+    kexec_script = pkgs.writeTextFile {
+      executable = true;
+      name = "kexec-nixos";
+      text = ''
+        #!${pkgs.stdenv.shell}
+        export PATH=${pkgs.kexectools}/bin:${pkgs.cpio}/bin:$PATH
+        set -x
+        set -e
+        kexec -l ${image}/kernel --initrd=${image}/initrd --append="init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}"
+        kexec -e
+        '';
+    };
+
+    kexec_tarball = lib.mkForce (pkgs.callPackage "${toString modulesPath}/../lib/make-system-tarball.nix" {
+      storeContents = [
+        {
+          object = config.system.build.kexec_script;
+          symlink = "/kexec_nixos";
+        }
+      ];
+      contents = [];
+    });
+
+    kexec_tarball_self_extract_script = pkgs.writeTextFile {
+      executable = true;
+      name = "kexec-nixos";
+      text = ''
+        #!/bin/sh
+        set -eu
+        ARCHIVE=`awk '/^__ARCHIVE_BELOW__/ { print NR + 1; exit 0; }' $0`
+
+        tail -n+$ARCHIVE $0 | tar xJ -C /
+        /kexec_nixos
+
+        exit 1
+
+        __ARCHIVE_BELOW__
+      '';
+    };
+
+    kexec_bundle = pkgs.runCommand "kexec_bundle" {} ''
+      cat \
+        ${kexec_tarball_self_extract_script} \
+        ${config.system.build.kexec_tarball}/tarball/nixos-system-${config.system.build.kexec_tarball.system}.tar.xz \
+        > $out
+      chmod +x $out
+    '';
+  };
+
+  boot.loader.grub.enable = lib.mkForce false;
+  boot.loader.systemd-boot.enable = lib.mkForce false;
+  boot.kernelParams = [
+    "console=ttyS0,115200" # allows certain forms of remote access, if the hardware is setup right
+    "panic=30"
+    "boot.panic_on_fail" # reboot the machine upon fatal boot issues
+  ];
+  systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
+  networking.hostName = lib.mkDefault "kexec";
+
+  formatAttr = "kexec_tarball";
+  fileExtension = ".tar.xz";
+
+  boot.initrd.postMountCommands = ''
+    mkdir -p /mnt-root/root/.ssh/
+    cp /authorized_keys /mnt-root/root/.ssh/
+  '';
+}

--- a/systems/kexec.nix
+++ b/systems/kexec.nix
@@ -50,7 +50,8 @@ let
 in
 inputs.nixos-generators.nixosGenerate {
   system = "x86_64-linux";
-  format = "kexec";
+  customFormats = { "kexec-nixos" = import ./custom-formats/kexec.nix; };
+  format = "kexec-nixos";
   modules = [
     kexec
   ];


### PR DESCRIPTION
What it says on the tin. Note that this doesn't yet support populating our configuration from the user-data, straightforward to add, however.