### PR TITLE
Initial netboot configuration for dynamic agent module import

### DIFF
--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -19,5 +19,8 @@ jobs:
       - name: Check Nix flake inputs
         uses: DeterminateSystems/flake-checker-action@v5
         with:
+          check-owner: false # we use our own custom fork of nixpkgs stored in other org on GitHub, so this check would fail otherwise
+          check-supported: false # we use our own custom fork of nixpkgs which uses dev as the unstable integration branch, so this check would fail otherwise
           ignore-missing-flake-lock: false
           fail-mode: true
+          send-statistics: false

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You must have the nix package installed for this build to work.
 make clean netboot
 cd result
 python3 -m http.server&
-qemu-system-x86_64 -enable-kvm -m 4G -cpu core2duo -serial mon:stdio -net user,bootfile="http://127.0.0.1:8000/ipxe" -net nic -msg timestamp=on
+qemu-system-x86_64 -enable-kvm -m 4G -cpu core2duo -serial mon:stdio -net user,bootfile="http://127.0.0.1:8000/ipxe_test_entrypoint" -net nic -msg timestamp=on
 ```
 
 ### FEATURE: SSH-Keys

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You must have the nix package installed for this build to work.
 make clean netboot
 cd result
 python3 -m http.server&
-qemu-system-x86_64 -enable-kvm -m 2G -cpu core2duo -serial mon:stdio -net user,bootfile="http://127.0.0.1:8000/ipxe" -net nic -msg timestamp=on
+qemu-system-x86_64 -enable-kvm -m 4G -cpu core2duo -serial mon:stdio -net user,bootfile="http://127.0.0.1:8000/ipxe" -net nic -msg timestamp=on
 ```
 
 ### FEATURE: SSH-Keys

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ You must have the nix package installed for this build to work.
 
 ## testing netboot
 ```
-$ make clean netboot
-$ cd result
-$ python3 -m http.server&
-$ qemu-system-x86_64 -enable-kvm -m 2G -cpu 2 -serial mon:stdio -net user,bootfile="http://127.0.0.1:8000/ipxe" -net nic -msg timestamp=on
+make clean netboot
+cd result
+python3 -m http.server&
+qemu-system-x86_64 -enable-kvm -m 2G -cpu core2duo -serial mon:stdio -net user,bootfile="http://127.0.0.1:8000/ipxe" -net nic -msg timestamp=on
 ```
 
 ### FEATURE: SSH-Keys

--- a/flake.lock
+++ b/flake.lock
@@ -52,17 +52,18 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712222121,
-        "narHash": "sha256-8f3glF4uwsPlDvaKDRgXD9xGe4YoCH4jA8ICxy/NbCo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "23ff7d9dc4f3d553939e7bfe0d2667198f993536",
+        "lastModified": 1718771219,
+        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
+        "owner": "openmesh-network",
+        "repo": "xnodepkgs",
+        "rev": "373929394f8f5fb03e84caabf7ffab10e318e299",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixpkgs-unstable",
-        "type": "indirect"
+        "owner": "openmesh-network",
+        "ref": "dev",
+        "repo": "xnodepkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Xnode OS";
   inputs = {
-    nixpkgs.url = "flake:nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:openmesh-network/xnodepkgs/dev";
     nixos-generators.url = "github:nix-community/nixos-generators";
   };
   outputs = inputs:

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -54,7 +54,7 @@ in
 
       serviceConfig = {
         ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir}/${cfg.localStateFilename} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
-        ExecStartPre = ''(test -d ${cfg.stateDir}/xnodeos && ${lib.getExe pkgs.git} -C ${cfg.stateDir}/xnodeos pull --rebase) || ${lib.getExe pkgs.git} clone --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
+        ExecStartPre = ''-${lib.getExe pkgs.git} clone --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
         Restart = "always";
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "openmesh-xnode-admin";

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -53,7 +53,7 @@ in
       wants = [ "network-online.target" ];
 
       serviceConfig = {
-        ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir}/${cfg.localStateFilename} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
+        ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
         ExecStartPre = ''-${lib.getExe pkgs.git} clone --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
         Restart = "always";
         WorkingDirectory = cfg.stateDir;

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -54,6 +54,7 @@ in
 
       serviceConfig = {
         ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir}/${cfg.localStateFilename} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
+        ExecStartPre = ''${lib.getExe pkgs.git} clone https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
         Restart = "always";
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "openmesh-xnode-admin";

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -54,7 +54,7 @@ in
 
       serviceConfig = {
         ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir}/${cfg.localStateFilename} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
-        ExecStartPre = ''${lib.getExe pkgs.git} clone https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
+        ExecStartPre = ''${lib.getExe pkgs.git} clone --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
         Restart = "always";
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "openmesh-xnode-admin";

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -55,6 +55,7 @@ in
       serviceConfig = {
         ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
         ExecStartPre = ''-${lib.getExe pkgs.git} clone --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
+        ExecCondition = ''-${lib.getExe pkgs.git} pull --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
         Restart = "always";
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "openmesh-xnode-admin";
@@ -62,18 +63,18 @@ in
         RuntimeDirectory = "openmesh-xnode-admin";
         RuntimeDirectoryMode = "0775";
         PrivateTmp = true;
-        DynamicUser = true;
-        DevicePolicy = "closed";
-        LockPersonality = true;
-        PrivateUsers = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectControlGroups = true;
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
+        User="root";
+        #DevicePolicy = "closed";
+        #LockPersonality = true;
+        #PrivateUsers = true;
+        #ProtectHome = true;
+        #ProtectHostname = true;
+        #ProtectKernelLogs = true;
+        #ProtectKernelModules = true;
+        #ProtectKernelTunables = true;
+        #ProtectControlGroups = true;
+        #RestrictNamespaces = true;
+        #RestrictRealtime = true;
         SystemCallArchitectures = "native";
         Environment="NIX_PATH=nixpkgs=flake:nixpkgs:/nix/var/nix/profiles/per-user/root/channels";
       };

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -49,16 +49,17 @@ in
     systemd.services.openmesh-xnode-admin = {
       description = "Openmesh Xnode Administration and Configuration Subsystem Daemon";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
 
       serviceConfig = {
         ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir}/${cfg.localStateFilename} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
         Restart = "always";
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "openmesh-xnode-admin";
-        StateDirectoryMode = "0755";
+        StateDirectoryMode = "0775";
         RuntimeDirectory = "openmesh-xnode-admin";
-        RuntimeDirectoryMode = "0755";
+        RuntimeDirectoryMode = "0775";
         PrivateTmp = true;
         DynamicUser = true;
         DevicePolicy = "closed";
@@ -73,7 +74,6 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
         SystemCallArchitectures = "native";
-        UMask = "0077";
       };
     };
 

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -54,7 +54,7 @@ in
 
       serviceConfig = {
         ExecStart = ''${lib.getExe cfg.package} -p ${cfg.stateDir}/${cfg.localStateFilename} ${cfg.remoteDir} ${toString cfg.searchInterval}''; 
-        ExecStartPre = ''${lib.getExe pkgs.git} clone --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
+        ExecStartPre = ''(test -d ${cfg.stateDir}/xnodeos && ${lib.getExe pkgs.git} -C ${cfg.stateDir}/xnodeos pull --rebase) || ${lib.getExe pkgs.git} clone --branch feature/import-agent-config-dynamically https://github.com/openmesh-network/xnodeos ${cfg.stateDir}/xnodeos'';
         Restart = "always";
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "openmesh-xnode-admin";

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -75,6 +75,7 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
         SystemCallArchitectures = "native";
+        Environment="NIX_PATH=nixpkgs=flake:nixpkgs:/nix/var/nix/profiles/per-user/root/channels";
       };
     };
 

--- a/repo/modules/services/openmesh/xnode/admin.nix
+++ b/repo/modules/services/openmesh/xnode/admin.nix
@@ -14,7 +14,7 @@ in
 
     stateDir = mkOption {
       type = types.str;
-      default = "/var/lib/openmesh-xnode-admin/default.nix";
+      default = "/var/lib/openmesh-xnode-admin";
       description = "State storage directory.";
     };
 
@@ -32,7 +32,7 @@ in
 
     remoteDir = mkOption {
       type = types.str;
-      default = "https://openmesh.network/xnodes/functions";
+      default = "https://dpl-backend-staging.up.railway.app/xnodes/functions";
       description = "The remote repository to pull down a configuration from.";
     };
 
@@ -41,7 +41,6 @@ in
       default = 0;
       description = "Number of seconds between fetching for changes to configuration.";
     };
-    # Todo: UUID + PSK implementation
   };
 
   config = lib.mkIf cfg.enable {
@@ -57,6 +56,7 @@ in
         Restart = "always";
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "openmesh-xnode-admin";
+        StateDirectoryMode = "0755";
         RuntimeDirectory = "openmesh-xnode-admin";
         RuntimeDirectoryMode = "0755";
         PrivateTmp = true;

--- a/repo/pkgs/openmesh/xnode/admin/default.nix
+++ b/repo/pkgs/openmesh/xnode/admin/default.nix
@@ -8,8 +8,8 @@ pkgs.python3Packages.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "Openmesh-Network";
     repo = pname;
-    rev = "48f7724fe62308465572dc1d53842776b4a2dcdd";
-    sha256 = "19vmk9fxm3q0x6as2rrcr1dcrf68v1xwf1dbrphh98ivnqb4yfym";
+    rev = "b3ea84ac6d095dfaf260976dd04a84d2cd77c21c";
+    sha256 = "1q14lvppzyimmrpnmznxycv0x0k0d86h9v2mm7wyg9wqw45c1ypw";
   };
 
   nativeBuildInputs = [

--- a/repo/pkgs/openmesh/xnode/admin/default.nix
+++ b/repo/pkgs/openmesh/xnode/admin/default.nix
@@ -8,8 +8,8 @@ pkgs.python3Packages.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "Openmesh-Network";
     repo = pname;
-    rev = "43ff75e2cb8aba6203d6bdae8ec5ec4d875b4405";
-    sha256 = "0c7fvv7dw2fha93yqy6z4dnj8b78nq9j56ga0m0iqb7pra1rsni1";
+    rev = "3e0a41b1a10fe3b9f68ab01d709726933a8675dd";
+    sha256 = "19vmk9fxm3q0x6as2rrcr1dcrf68v1xwf1dbrphh98ivnqb4yfym";
   };
 
   nativeBuildInputs = [

--- a/repo/pkgs/openmesh/xnode/admin/default.nix
+++ b/repo/pkgs/openmesh/xnode/admin/default.nix
@@ -8,8 +8,8 @@ pkgs.python3Packages.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "Openmesh-Network";
     repo = pname;
-    rev = "2f44a5dea3323903e96519e013fe9022a7d449e8";
-    sha256 = "17hm66dk9bkx4267i5ilysn83r36ha0lllnf48zgcws7mxzhd6z6";
+    rev = "d75b6ac1f5bda1429437555e8996d3c6cf290ca7";
+    sha256 = "10dwga1fmlgd9gn6bh5w74zrd7r1q4saqzi5mj8p2673v9js85qj";
   };
 
   nativeBuildInputs = [

--- a/repo/pkgs/openmesh/xnode/admin/default.nix
+++ b/repo/pkgs/openmesh/xnode/admin/default.nix
@@ -8,8 +8,8 @@ pkgs.python3Packages.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "Openmesh-Network";
     repo = pname;
-    rev = "d75b6ac1f5bda1429437555e8996d3c6cf290ca7";
-    sha256 = "10dwga1fmlgd9gn6bh5w74zrd7r1q4saqzi5mj8p2673v9js85qj";
+    rev = "43ff75e2cb8aba6203d6bdae8ec5ec4d875b4405";
+    sha256 = "0c7fvv7dw2fha93yqy6z4dnj8b78nq9j56ga0m0iqb7pra1rsni1";
   };
 
   nativeBuildInputs = [

--- a/repo/pkgs/openmesh/xnode/admin/default.nix
+++ b/repo/pkgs/openmesh/xnode/admin/default.nix
@@ -8,8 +8,8 @@ pkgs.python3Packages.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "Openmesh-Network";
     repo = pname;
-    rev = "568ca78e3881f1b2af988b6846ab59f316f2e731";
-    sha256 = "e/GVoWFKEp54gZNkllAf7Q9rBogJ0bSa3aT62pelutw=";
+    rev = "2f44a5dea3323903e96519e013fe9022a7d449e8";
+    sha256 = "17hm66dk9bkx4267i5ilysn83r36ha0lllnf48zgcws7mxzhd6z6";
   };
 
   nativeBuildInputs = [

--- a/repo/pkgs/openmesh/xnode/admin/default.nix
+++ b/repo/pkgs/openmesh/xnode/admin/default.nix
@@ -8,7 +8,7 @@ pkgs.python3Packages.buildPythonPackage rec {
   src = pkgs.fetchFromGitHub {
     owner = "Openmesh-Network";
     repo = pname;
-    rev = "3e0a41b1a10fe3b9f68ab01d709726933a8675dd";
+    rev = "48f7724fe62308465572dc1d53842776b4a2dcdd";
     sha256 = "19vmk9fxm3q0x6as2rrcr1dcrf68v1xwf1dbrphh98ivnqb4yfym";
   };
 

--- a/systems/custom-formats/netboot.nix
+++ b/systems/custom-formats/netboot.nix
@@ -9,22 +9,37 @@
       mkdir $out
       cp ${config.system.build.kernel}/${config.system.boot.loader.kernelFile} $out/kernel
       cp ${config.system.build.netbootRamdisk}/initrd $out/initrd
+      cp ${config.system.build.ipxe_test_entrypoint_script} $out/ipxe_test_entrypoint
       cp ${config.system.build.ipxe_script} $out/ipxe
       echo "init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}" > $out/cmdline
 
       nuke-refs $out/kernel
     '';
-    xnode_version = "0";
-    xnode_uuid = "d9be30bf-1501-446d-8815-23fcb37a375c"; # XU Controller inserts these already
-    xnode_access_token = "RQ7YYfRP2J8BNkNDDQu5Kp8oLC1ajZMNLDtRYxLX8ylhFeImgq1RLvzp6FYOqa1B";
+
+    ipxe_test_entrypoint_script = pkgs.writeTextFile {
+      executable = false;
+      name = "ipxe_test_entrypoint";
+
+      text = ''
+        #!ipxe
+        set xnode_version 0
+        set xnode_uuid d9be30bf-1501-446d-8815-23fcb37a375c
+        set xnode_access_token RQ7YYfRP2J8BNkNDDQu5Kp8oLC1ajZMNLDtRYxLX8ylhFeImgq1RLvzp6FYOqa1B
+        chain http://127.0.0.1:8000/ipxe
+      '';
+    };
+
     ipxe_script = pkgs.writeTextFile {
       executable = false;
       name = "ipxe";
 
       text = ''
         #!ipxe
-        # TODO: MAKE CONFIGURABLE WITH iPXE VARS for CHAINLOAD
-        kernel http://127.0.0.1:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams} -- XNODE_VERSION=${xnode_version} XNODE_UUID=${xnode_uuid} XNODE_ACCESS_TOKEN=${xnode_access_token}
+        # Admin Service Expects the following to be set for initialisation in the chainloading iPXE script:
+        #   - xnode_version
+        #   - xnode_uuid
+        #   - xnode_access_token
+        kernel http://127.0.0.1:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams} -- XNODE_VERSION=''${xnode_version} XNODE_UUID=''${xnode_uuid} XNODE_ACCESS_TOKEN=''${xnode_access_token}
         initrd http://127.0.0.1:8000/initrd
         boot
       '';

--- a/systems/custom-formats/netboot.nix
+++ b/systems/custom-formats/netboot.nix
@@ -14,14 +14,17 @@
 
       nuke-refs $out/kernel
     '';
-
+    xnode_version = "0";
+    xnode_uuid = "303a03f7-0619-4bd2-85b7-a56c7e12c4b6"; # XU Controller inserts these already
+    xnode_access_token = "TEEH0Km2gOEppGnArOeqir776lr3F7GisdjRMeQ0YoX4rcmuilV3e5vaPFCM8JFn";
     ipxe_script = pkgs.writeTextFile {
       executable = false;
       name = "ipxe";
+
       text = ''
         #!ipxe
         # TODO: MAKE CONFIGURABLE WITH iPXE VARS for CHAINLOAD
-        kernel http://127.0.0.1:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+        kernel http://127.0.0.1:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams} XNODE_VERSION=${xnode_version} XNODE_UUID=${xnode_uuid} XNODE_ACCESS_TOKEN=${xnode_access_token}
         initrd http://127.0.0.1:8000/initrd
         boot
       '';

--- a/systems/custom-formats/netboot.nix
+++ b/systems/custom-formats/netboot.nix
@@ -15,8 +15,8 @@
       nuke-refs $out/kernel
     '';
     xnode_version = "0";
-    xnode_uuid = "303a03f7-0619-4bd2-85b7-a56c7e12c4b6"; # XU Controller inserts these already
-    xnode_access_token = "TEEH0Km2gOEppGnArOeqir776lr3F7GisdjRMeQ0YoX4rcmuilV3e5vaPFCM8JFn";
+    xnode_uuid = "d9be30bf-1501-446d-8815-23fcb37a375c"; # XU Controller inserts these already
+    xnode_access_token = "RQ7YYfRP2J8BNkNDDQu5Kp8oLC1ajZMNLDtRYxLX8ylhFeImgq1RLvzp6FYOqa1B";
     ipxe_script = pkgs.writeTextFile {
       executable = false;
       name = "ipxe";

--- a/systems/custom-formats/netboot.nix
+++ b/systems/custom-formats/netboot.nix
@@ -24,7 +24,7 @@
       text = ''
         #!ipxe
         # TODO: MAKE CONFIGURABLE WITH iPXE VARS for CHAINLOAD
-        kernel http://127.0.0.1:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams} XNODE_VERSION=${xnode_version} XNODE_UUID=${xnode_uuid} XNODE_ACCESS_TOKEN=${xnode_access_token}
+        kernel http://127.0.0.1:8000/kernel initrd=initrd init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams} -- XNODE_VERSION=${xnode_version} XNODE_UUID=${xnode_uuid} XNODE_ACCESS_TOKEN=${xnode_access_token}
         initrd http://127.0.0.1:8000/initrd
         boot
       '';

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -24,6 +24,7 @@ let
           };
         };
         getty = {
+          autologinUser = lib.mkForce "xnode";
           greetingLine = ''<<< Welcome to Openmesh XnodeOS ${config.system.nixos.label} (\m) - \l >>>'';
         };
       };
@@ -36,7 +37,82 @@ let
         squashfsCompression = "gzip -Xcompression-level 1";
       };
       boot = {
-        postBootCommands = ''echo '{config,lib,pkgs,...}:{imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/config.nix) /var/lib/openmesh-xnode-admin/config.nix; boot.loader.grub.enable=false;}' > /etc/nixos/configuration.nix && echo '{config,lib,pkgs,modulesPath,...}:{fileSystems."/"={device="tmpfs";fsType="tmpfs";};nixpkgs.hostPlatform=lib.mkDefault "x86_64-linux";}' > /etc/nixos/hardware-configuration.nix'';
+        postBootCommands = ''
+                            cat > /etc/nixos/configuration.nix <<ENDFILE
+                            {config, lib, pkgs, ...}:{
+                              imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/config.nix) /var/lib/openmesh-xnode-admin/config.nix ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/xnodeos) /var/lib/openmesh-xnode-admin/xnodeos/repo/modules/services/openmesh/xnode/admin.nix ;
+                              config = {
+                                nix.settings.experimental-features = [ "nix-command" "flakes" ];
+                                boot.loader.grub.enable=false;
+                                services.openmesh.xnode.admin = {
+                                  enable = true;
+                                  remoteDir = "https://dpl-backend-staging.up.railway.app/xnodes/functions";
+                                };
+                                users.users = {
+                                  "xnode" = {
+                                    isNormalUser = true;
+                                    password = "xnode";
+                                    extraGroups = [ "wheel" ];
+                                  };
+                                };
+                              };
+                            }
+                            ENDFILE
+
+                            cat > /etc/nixos/hardware-configuration.nix <<ENDFILE
+                            {config, lib, pkgs, modulesPath, ...}: {
+                              fileSystems = {
+                                "/" = {
+                                  fsType = "tmpfs";
+                                  options = [ "mode=0755" "size=80%" ];
+                                };
+
+                                "/nix/.ro-store" = {
+                                  fsType = "squashfs";
+                                  device = "/dev/loop0";
+                                  options = [ "loop" ];
+                                  neededForBoot = true;
+                                };
+
+                                "/nix/.rw-store" = {
+                                  fsType = "tmpfs";
+                                  options = [ "mode=0755" ];
+                                  neededForBoot = true;
+                                };
+
+                                "/nix/store" = {
+                                  neededForBoot = true;
+                                  fsType = "overlay";
+                                  device = "overlay";
+                                  options = [
+                                    "lowerdir=/nix/.ro-store"
+                                    "upperdir=/nix/.rw-store/store"
+                                    "workdir=/nix/.rw-store/work"
+                                  ];
+                                };
+
+                              };
+
+                              networking.useDHCP = lib.mkForce true;
+
+                              boot.initrd = {
+                                availableKernelModules = [
+                                  # To mount /nix/store
+                                  "squashfs"
+                                  "overlay"
+                                ];
+                                kernelModules = [
+                                  "loop"
+                                  "overlay"
+                                ];
+
+                                network.enable = true;
+                              };
+
+                              nixpkgs.hostPlatform=lib.mkDefault "x86_64-linux";
+                            }
+                            ENDFILE
+                          '';
       };
       networking = {
         hostName = "xnode";

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -5,6 +5,7 @@ let
       ../repo/modules/services/openmesh/xnode/admin.nix
     ];
     config = {
+      nix.settings.experimental-features = [ "nix-command" "flakes" ];
       documentation = {
         nixos = {
           enable = false;
@@ -24,7 +25,6 @@ let
         };
         getty = {
           greetingLine = ''<<< Welcome to Openmesh XnodeOS ${config.system.nixos.label} (\m) - \l >>>'';
-          autologinUser = lib.mkForce "xnode";
         };
       };
       environment = {
@@ -36,8 +36,7 @@ let
         squashfsCompression = "gzip -Xcompression-level 1";
       };
       boot = {
-        postBootCommands = ''nixos-generate-config; echo '{config,lib,pkgs,...}:{imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists /home/xnode/config.nix) /home/xnode/config.nix; boot.loader.grub.enable=false;}' > /etc/nixos/configuration.nix'';
-        # Fixme: Hardcoded import location /var/lib/openmesh-xnode-admin/config.nix
+        postBootCommands = ''echo '{config,lib,pkgs,...}:{imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/config.nix) /var/lib/openmesh-xnode-admin/config.nix; boot.loader.grub.enable=false;}' > /etc/nixos/configuration.nix && echo '{config,lib,pkgs,modulesPath,...}:{fileSystems."/"={device="tmpfs";fsType="tmpfs";};nixpkgs.hostPlatform=lib.mkDefault "x86_64-linux";}' > /etc/nixos/hardware-configuration.nix'';
       };
       networking = {
         hostName = "xnode";

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -6,7 +6,7 @@ let
     ];
     config = {
       nix.settings.experimental-features = [ "nix-command" "flakes" ];
-      nix.settings.trusted-users = [ "root" "xnode" ];
+      nix.settings.trusted-users = [ "root" "xnode" "openmesh-xnode-admin" ];
       documentation = {
         nixos = {
           enable = false;
@@ -44,7 +44,7 @@ let
                               imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/config.nix) /var/lib/openmesh-xnode-admin/config.nix ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/xnodeos) /var/lib/openmesh-xnode-admin/xnodeos/repo/modules/services/openmesh/xnode/admin.nix ;
                               config = {
                                 nix.settings.experimental-features = [ "nix-command" "flakes" ];
-                                nix.settings.trusted-users = [ "root" "xnode" ];
+                                nix.settings.trusted-users = [ "root" "xnode" "openmesh-xnode-admin" ];
                                 boot.loader.grub.enable=false;
                                 services.openmesh.xnode.admin = {
                                   enable = true;
@@ -65,51 +65,12 @@ let
                             {config, lib, pkgs, modulesPath, ...}: {
                               fileSystems = {
                                 "/" = {
+                                  device = "none";
                                   fsType = "tmpfs";
-                                  options = [ "mode=0755" "size=80%" ];
                                 };
-
-                                "/nix/.ro-store" = {
-                                  fsType = "squashfs";
-                                  device = "/dev/loop0";
-                                  options = [ "loop" ];
-                                  neededForBoot = true;
-                                };
-
-                                "/nix/.rw-store" = {
-                                  fsType = "tmpfs";
-                                  options = [ "mode=0755" ];
-                                  neededForBoot = true;
-                                };
-
-                                "/nix/store" = {
-                                  neededForBoot = true;
-                                  fsType = "overlay";
-                                  device = "overlay";
-                                  options = [
-                                    "lowerdir=/nix/.ro-store"
-                                    "upperdir=/nix/.rw-store/store"
-                                    "workdir=/nix/.rw-store/work"
-                                  ];
-                                };
-
                               };
 
                               networking.useDHCP = lib.mkForce true;
-
-                              boot.initrd = {
-                                availableKernelModules = [
-                                  "squashfs"
-                                  "overlay"
-                                ];
-                                kernelModules = [
-                                  "loop"
-                                  "overlay"
-                                ];
-
-                                network.enable = true;
-                              };
-
                               nixpkgs.hostPlatform=lib.mkDefault "x86_64-linux";
                             }
                             ENDFILE

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -6,6 +6,7 @@ let
     ];
     config = {
       nix.settings.experimental-features = [ "nix-command" "flakes" ];
+      nix.settings.trusted-users = [ "root" "xnode" ];
       documentation = {
         nixos = {
           enable = false;
@@ -43,6 +44,7 @@ let
                               imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/config.nix) /var/lib/openmesh-xnode-admin/config.nix ++ lib.optional (builtins.pathExists /var/lib/openmesh-xnode-admin/xnodeos) /var/lib/openmesh-xnode-admin/xnodeos/repo/modules/services/openmesh/xnode/admin.nix ;
                               config = {
                                 nix.settings.experimental-features = [ "nix-command" "flakes" ];
+                                nix.settings.trusted-users = [ "root" "xnode" ];
                                 boot.loader.grub.enable=false;
                                 services.openmesh.xnode.admin = {
                                   enable = true;
@@ -97,7 +99,6 @@ let
 
                               boot.initrd = {
                                 availableKernelModules = [
-                                  # To mount /nix/store
                                   "squashfs"
                                   "overlay"
                                 ];

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -24,6 +24,7 @@ let
         };
         getty = {
           greetingLine = ''<<< Welcome to Openmesh XnodeOS ${config.system.nixos.label} (\m) - \l >>>'';
+          autologinUser = lib.mkForce "xnode";
         };
       };
       environment = {
@@ -35,7 +36,8 @@ let
         squashfsCompression = "gzip -Xcompression-level 1";
       };
       boot = {
-        postBootCommands = ''nixos-generate-config && echo '{config,lib,pkgs,...}:{imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists ./local-configuration.nix) ./local-configuration.nix; boot.loader.grub.enable=false;}' > /etc/nixos/configuration.nix'';
+        postBootCommands = ''nixos-generate-config; echo '{config,lib,pkgs,...}:{imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists /home/xnode/config.nix) /home/xnode/config.nix; boot.loader.grub.enable=false;}' > /etc/nixos/configuration.nix'';
+        # Fixme: Hardcoded import location /var/lib/openmesh-xnode-admin/config.nix
       };
       networking = {
         hostName = "xnode";

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -33,6 +33,9 @@ let
       netboot = {
         squashfsCompression = "gzip -Xcompression-level 1";
       };
+      boot = {
+        postBootCommands = ''nixos-generate-config && echo '{config,lib,pkgs,...}:{imports=[./hardware-configuration.nix] ++ lib.optional (builtins.pathExists ./local-configuration.nix) ./local-configuration.nix; boot.loader.grub.enable=false;}' > /etc/nixos/configuration.nix'';
+      };
       networking = {
         hostName = "xnode";
       };

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -1,5 +1,6 @@
 { inputs, ... }@flakeContext:
 let
+  pkgs = inputs.nixpkgs;
   netboot = { config, lib, pkgs, ... }: {
     imports = [
       ../repo/modules/services/openmesh/xnode/admin.nix
@@ -46,6 +47,7 @@ let
                                 nix.settings.experimental-features = [ "nix-command" "flakes" ];
                                 nix.settings.trusted-users = [ "root" "xnode" "openmesh-xnode-admin" ];
                                 boot.loader.grub.enable=false;
+                                nixpkgs.config.allowUnfree = true;
                                 services.openmesh.xnode.admin = {
                                   enable = true;
                                   remoteDir = "https://dpl-backend-staging.up.railway.app/xnodes/functions";

--- a/systems/netboot.nix
+++ b/systems/netboot.nix
@@ -21,7 +21,7 @@ let
           xnode = {
             admin = {
               enable = true;
-              remoteDir = "https://dpl-backend-staging.up.railway.app/xnodes/functions";
+              remoteDir = "http://dpl-staging.openmesh.network/xnodes/functions";
             };
           };
         };
@@ -50,7 +50,7 @@ let
                                 nixpkgs.config.allowUnfree = true;
                                 services.openmesh.xnode.admin = {
                                   enable = true;
-                                  remoteDir = "https://dpl-backend-staging.up.railway.app/xnodes/functions";
+                                  remoteDir = "https://dpl-staging.openmesh.network/xnodes/functions";
                                 };
                                 users.users = {
                                   "xnode" = {


### PR DESCRIPTION
Initial implementation for configuration generation and emplacement. Existing configuration will need to be placed into this particular file/image path (perhaps in the builder) so that the image configuration gets pulled into the xnode on first nixos-rebuild. nixos-generate-config is needed so that hardware-configuration is automatically generated appropriately for the hardware which is running the xnode.