### PR TITLE
kexec convenience script interface to provide ability to set kernel parameters

### DIFF
--- a/systems/custom-formats/kexec.nix
+++ b/systems/custom-formats/kexec.nix
@@ -28,7 +28,7 @@ in {
         export PATH=${pkgs.kexectools}/bin:${pkgs.cpio}/bin:$PATH
         set -x
         set -e
-        kexec -l ${image}/kernel --initrd=${image}/initrd --append="init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams}"
+        kexec -l ${image}/kernel --initrd=${image}/initrd --append="init=${builtins.unsafeDiscardStringContext config.system.build.toplevel}/init ${toString config.boot.kernelParams} ''$@"
         kexec -e
         '';
     };


### PR DESCRIPTION
This permits the configuration of things like XnodeOS Admin Agent in the XnodeOS system - which depends on certain /proc/cmdline parameters being set/available at runtime.