### PR TITLE
We need to be able to access the latest dev and main branch builds on the web for netboot, ISO sideload, etc.

### DIFF
--- a/.github/workflows/xnodeos-build-iso.yml
+++ b/.github/workflows/xnodeos-build-iso.yml
@@ -23,3 +23,12 @@ jobs:
         with:
           name: XnodeOS-x86_64.iso
           path: result/iso/nixos.iso
+      - name: Upload Result to boot.opnm.sh
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: boot.opnm.sh
+          username: opnm
+          key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
+          source: result/iso/nixos.iso
+          target: /public/${{GITHUB_REF_NAME}}/iso
+          strip_components: 2

--- a/.github/workflows/xnodeos-build-iso.yml
+++ b/.github/workflows/xnodeos-build-iso.yml
@@ -30,7 +30,7 @@ jobs:
           username: opnm
           key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
           source: result/iso/nixos.iso
-          target: /public/${{GITHUB_REF_NAME}}/iso
+          target: /mnt/boot-opnm-sh/public/${{GITHUB_REF_NAME}}/iso
           strip_components: 2
           tar_dereference: true
           overwrite: true

--- a/.github/workflows/xnodeos-build-iso.yml
+++ b/.github/workflows/xnodeos-build-iso.yml
@@ -32,3 +32,5 @@ jobs:
           source: result/iso/nixos.iso
           target: /public/${{GITHUB_REF_NAME}}/iso
           strip_components: 2
+          tar_dereference: true
+          overwrite: true

--- a/.github/workflows/xnodeos-build-kexec.yml
+++ b/.github/workflows/xnodeos-build-kexec.yml
@@ -31,7 +31,7 @@ jobs:
           username: opnm
           key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
           source: result/tarball/nixos-system-x86_64-linux.tar.xz
-          target: /public/latest/${{GITHUB_REF_NAME}}/kexec
+          target: /mnt/boot-opnm-sh/public/latest/${{GITHUB_REF_NAME}}/kexec
           strip_components: 2
           tar_dereference: true
           overwrite: true

--- a/.github/workflows/xnodeos-build-kexec.yml
+++ b/.github/workflows/xnodeos-build-kexec.yml
@@ -33,3 +33,5 @@ jobs:
           source: result/tarball/nixos-system-x86_64-linux.tar.xz
           target: /public/latest/${{GITHUB_REF_NAME}}/kexec
           strip_components: 2
+          tar_dereference: true
+          overwrite: true

--- a/.github/workflows/xnodeos-build-kexec.yml
+++ b/.github/workflows/xnodeos-build-kexec.yml
@@ -24,3 +24,12 @@ jobs:
         with:
           name: xnodeos-kexec-system-x86_64-linux.tar.xz
           path: result/tarball/nixos-system-x86_64-linux.tar.xz
+      - name: Upload Result to boot.opnm.sh
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: boot.opnm.sh
+          username: opnm
+          key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
+          source: result/tarball/nixos-system-x86_64-linux.tar.xz
+          target: /public/latest/${{GITHUB_REF_NAME}}/kexec
+          strip_components: 2

--- a/.github/workflows/xnodeos-build-netboot.yml
+++ b/.github/workflows/xnodeos-build-netboot.yml
@@ -41,7 +41,7 @@ jobs:
           username: opnm
           key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
           source: "result/ipxe,result/kernel,result/initrd"
-          target: /public/latest/${{GITHUB_REF_NAME}}/netboot
+          target: /mnt/boot-opnm-sh/public/latest/${{GITHUB_REF_NAME}}/netboot
           strip_components: 1
           tar_dereference: true
           overwrite: true

--- a/.github/workflows/xnodeos-build-netboot.yml
+++ b/.github/workflows/xnodeos-build-netboot.yml
@@ -34,3 +34,12 @@ jobs:
         with:
           name: initrd
           path: result/initrd
+      - name: Upload Result to boot.opnm.sh
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: boot.opnm.sh
+          username: opnm
+          key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
+          source: "result/ipxe,result/kernel,result/initrd"
+          target: /public/latest/${{GITHUB_REF_NAME}}/netboot
+          strip_components: 1

--- a/.github/workflows/xnodeos-build-netboot.yml
+++ b/.github/workflows/xnodeos-build-netboot.yml
@@ -43,3 +43,5 @@ jobs:
           source: "result/ipxe,result/kernel,result/initrd"
           target: /public/latest/${{GITHUB_REF_NAME}}/netboot
           strip_components: 1
+          tar_dereference: true
+          overwrite: true


### PR DESCRIPTION
What it says on the tin.

https://boot.opnm.sh is now served from a personal server I control (to be moved under org control ASAP), which accepts SSH connections to the opnm chrooted user. This github action is well known and performs an SCP of the build results up to a well-known directory. This file is then served at https://boot.opnm.sh/latest/{branch name}/{artifact type}/...

HTTPS cert is issued by let's encrypt.