### PR TITLE
Context names must be used instead of envrionment variables as that's what's expected by the GitHub Workflow Schema

### DIFF
--- a/.github/workflows/xnodeos-build-iso.yml
+++ b/.github/workflows/xnodeos-build-iso.yml
@@ -30,7 +30,7 @@ jobs:
           username: opnm
           key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
           source: result/iso/nixos.iso
-          target: /mnt/boot-opnm-sh/public/${{GITHUB_REF_NAME}}/iso
+          target: /mnt/boot-opnm-sh/public/${{github.ref_name}}/iso
           strip_components: 2
           tar_dereference: true
           overwrite: true

--- a/.github/workflows/xnodeos-build-kexec.yml
+++ b/.github/workflows/xnodeos-build-kexec.yml
@@ -31,7 +31,7 @@ jobs:
           username: opnm
           key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
           source: result/tarball/nixos-system-x86_64-linux.tar.xz
-          target: /mnt/boot-opnm-sh/public/latest/${{GITHUB_REF_NAME}}/kexec
+          target: /mnt/boot-opnm-sh/public/latest/${{github.ref_name}}/kexec
           strip_components: 2
           tar_dereference: true
           overwrite: true

--- a/.github/workflows/xnodeos-build-netboot.yml
+++ b/.github/workflows/xnodeos-build-netboot.yml
@@ -41,7 +41,7 @@ jobs:
           username: opnm
           key: ${{secrets.BOOT_OPNM_SH_DEPLOY_KEY}}
           source: "result/ipxe,result/kernel,result/initrd"
-          target: /mnt/boot-opnm-sh/public/latest/${{GITHUB_REF_NAME}}/netboot
+          target: /mnt/boot-opnm-sh/public/latest/${{github.ref_name}}/netboot
           strip_components: 1
           tar_dereference: true
           overwrite: true


### PR DESCRIPTION
What it says on the tin.